### PR TITLE
Add goreleaser and optimize docker image

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,28 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v4
+        with:
+          go-version: stable
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,16 @@
-FROM golang:1.18.3-alpine
+FROM golang:1.18.3-alpine as build
 
-RUN mkdir -p /go/src/github.com/dpliakos/jorge
-WORKDIR /go/src/github.com/dpliakos/jorge
+WORKDIR /app
+COPY go.mod go.sum /app/
+RUN go mod download
 
-RUN apk add make
+COPY . .
+RUN go build
 
-COPY ./main.go  .
-COPY ./cmd ./cmd
-COPY ./internal ./internal
-COPY ./go.mod .
-COPY ./go.sum .
-COPY ./LICENSE .
-COPY ./Makefile .
+FROM alpine:3.17.5 as final
 
-RUN go get
-RUN make build
-RUN make install 
+USER 1000
+COPY --from=build /app/jorge /jorge
 
-RUN mkdir /root/projectRoot
-WORKDIR /root/projectRoot
+WORKDIR /projectRoot
+ENTRYPOINT ["/jorge"]


### PR DESCRIPTION
This adds goreleaser to the pipeline and runs on tags created. While at it I also optimized the dockerfile as it was outdated and was using the old, not-go-mod way of handling dependencies.

Closes #11 